### PR TITLE
Polish modpack website UI, add Wiki Hub and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,292 +1,64 @@
-# Minecraft Modpack Website
+# Minecraft Modpack Website Template
 
-A fully configurable website for your Minecraft modpack with home page, gallery, and community-editable wiki.
+A clean, configurable static website for Minecraft modpacks with:
 
-## 🚀 Quick Start
+- polished landing page
+- gallery with lightbox
+- wiki hub (categories + featured pages)
+- GitHub Pages deployment workflow
 
-1. **Edit `config.json`** - This controls ALL content on your website
-2. **Add your screenshots** to the `images/` folder
-3. **Set up your GitHub wiki repository** (instructions below)
-4. **Deploy** to GitHub Pages, Netlify, or any static host
+## Quick Start
 
-## 📝 Configuration Guide
+1. Edit `config.json` with your modpack details and links.
+2. Add screenshots to `images/` and reference them in `config.json`.
+3. Push to GitHub and enable Pages (workflow included).
 
-Everything is controlled through `config.json`. No code editing required!
+## Configuration
 
-### Basic Information
+Everything is controlled through `config.json`.
+
+### Important fields
+
+- `modpack`: website title, tagline, description, versions
+- `links.curseforge`: download link
+- `links.discord`: optional community invite
+- `links.github`: either `owner/repo` or full GitHub URL
+- `wiki.categories`: category chips shown in the wiki hub
+- `wiki.pages`: featured wiki cards with title, summary, and markdown file
+- `theme`: color overrides
+
+### Wiki file links
+
+Wiki links are generated as:
+
+`https://github.com/<repo>/blob/<branch>/wiki/<file>.md`
+
+So if you add:
 
 ```json
-"modpack": {
-    "name": "Your Modpack Name",
-    "tagline": "An Epic Adventure Awaits",
-    "description": "Your modpack description here...",
-    "version": "1.0.0",
-    "minecraftVersion": "1.20.1"
+{
+  "title": "Progression Path",
+  "file": "progression-guide.md"
 }
 ```
 
-### Links
+create the file at:
 
-```json
-"links": {
-    "curseforge": "https://www.curseforge.com/minecraft/modpacks/your-modpack",
-    "discord": "https://discord.gg/your-invite",
-    "github": "yourusername/modpack-wiki"
-}
+`wiki/progression-guide.md` in your wiki repo.
+
+## Deploying to GitHub Pages
+
+This repo includes `.github/workflows/deploy-pages.yml`.
+
+1. Push to the `main` branch.
+2. In GitHub, open **Settings → Pages**.
+3. Set **Source** to **GitHub Actions**.
+4. The workflow deploys this static site automatically.
+
+## Local Preview
+
+```bash
+python3 -m http.server 4173
 ```
 
-### Features
-
-Add or remove features as needed:
-
-```json
-"features": [
-    {
-        "title": "Epic Exploration",
-        "description": "Discover dozens of new biomes...",
-        "icon": "🗺️"
-    }
-]
-```
-
-Icons can be any emoji! 🎮⚔️🏰🌍🔥💎⭐
-
-### Gallery Images
-
-```json
-"gallery": {
-    "images": [
-        {
-            "url": "images/screenshot1.png",
-            "title": "Exploring New Dimensions",
-            "description": "Venture into mysterious new worlds"
-        }
-    ]
-}
-```
-
-### Wiki Categories
-
-```json
-"wiki": {
-    "githubRepo": "yourusername/modpack-wiki",
-    "branch": "main",
-    "categories": [
-        "Getting Started",
-        "Mods List",
-        "Progression Guide"
-    ]
-}
-```
-
-### Theme Colors
-
-Customize the color scheme:
-
-```json
-"theme": {
-    "primaryColor": "#d97706",
-    "secondaryColor": "#92400e",
-    "accentColor": "#fbbf24",
-    "backgroundColor": "#1c1917",
-    "textColor": "#fafaf9"
-}
-```
-
-## 🖼️ Adding Screenshots
-
-1. Create an `images/` folder in your website directory
-2. Add your screenshots (PNG or JPG recommended)
-3. Update `config.json` with the image paths:
-
-```json
-"gallery": {
-    "images": [
-        {
-            "url": "images/my-screenshot.png",
-            "title": "Amazing Build",
-            "description": "Check out this structure"
-        }
-    ]
-}
-```
-
-## 📚 Setting Up the Community Wiki
-
-The wiki lives in a separate GitHub repository that anyone can contribute to via pull requests.
-
-### Step 1: Create Wiki Repository
-
-1. Go to GitHub and create a new repository (e.g., `yourname/modpack-wiki`)
-2. Initialize it with a README
-3. Create a `wiki/` folder
-
-### Step 2: Create Wiki Pages
-
-Create markdown files in the `wiki/` folder:
-
-```
-modpack-wiki/
-├── README.md
-└── wiki/
-    ├── getting-started.md
-    ├── mods-list.md
-    ├── progression-guide.md
-    ├── dimensions.md
-    ├── bosses.md
-    └── faq.md
-```
-
-### Step 3: Wiki Template
-
-Here's a template for wiki pages:
-
-```markdown
-# Getting Started
-
-Welcome to the modpack! This guide will help you begin your adventure.
-
-## Installation
-
-1. Download the modpack from [CurseForge](your-link-here)
-2. Install using your preferred launcher
-3. Allocate at least 6GB of RAM
-
-## First Steps
-
-- Spawn in and gather basic resources
-- Follow the quest book
-- Explore nearby areas
-
-## Tips for Beginners
-
-- Start with basic tools
-- Join our Discord for help
-- Check the progression guide
-```
-
-### Step 4: Enable Community Contributions
-
-1. In your repo settings, enable "Issues" and "Pull Requests"
-2. Add a `CONTRIBUTING.md` file with guidelines
-3. Users can now fork, edit, and submit improvements!
-
-### Step 5: Update Your Website
-
-Update `config.json`:
-
-```json
-"links": {
-    "github": "yourusername/modpack-wiki"
-},
-"wiki": {
-    "githubRepo": "yourusername/modpack-wiki",
-    "branch": "main",
-    "categories": [
-        "Getting Started",
-        "Mods List",
-        "Progression Guide",
-        "Dimensions",
-        "Bosses",
-        "FAQ"
-    ]
-}
-```
-
-The category names should match your markdown filenames (converted to lowercase with hyphens).
-
-## 🌐 Deployment Options
-
-### GitHub Pages (Free & Easy)
-
-1. Create a GitHub repository for your website
-2. Push these files to the repository
-3. Go to Settings → Pages
-4. Select "Deploy from branch" → main → root
-5. Your site will be live at `https://yourusername.github.io/repo-name`
-
-### Netlify (Free & Automatic)
-
-1. Sign up at [Netlify](https://netlify.com)
-2. Drag and drop your website folder
-3. Done! You get a custom URL instantly
-4. Optional: Connect your GitHub repo for automatic updates
-
-### Vercel (Free & Fast)
-
-1. Sign up at [Vercel](https://vercel.com)
-2. Import your GitHub repository
-3. Deploy with one click
-
-## 📁 File Structure
-
-```
-your-website/
-├── index.html          # Main HTML (don't edit unless needed)
-├── styles.css          # Styling (customize if desired)
-├── script.js           # JavaScript (handles config loading)
-├── config.json         # ⭐ EDIT THIS to configure everything
-├── images/             # Your screenshots go here
-│   ├── screenshot1.png
-│   ├── screenshot2.png
-│   └── ...
-└── README.md           # This file
-```
-
-## 🎨 Customization Tips
-
-### Change the Font
-
-In `index.html`, find the Google Fonts link and replace with your preferred fonts:
-
-```html
-<link href="https://fonts.googleapis.com/css2?family=YourFont:wght@400;700&display=swap" rel="stylesheet">
-```
-
-Then update in `styles.css`:
-
-```css
-body {
-    font-family: 'YourFont', sans-serif;
-}
-```
-
-### Add More Sections
-
-You can add custom sections by editing `index.html` and `styles.css`. Follow the existing pattern.
-
-### Animations
-
-The site includes smooth animations and transitions. These are defined in `styles.css` if you want to adjust them.
-
-## 🔧 Troubleshooting
-
-### Images not showing?
-
-- Make sure the image paths in `config.json` match your actual file locations
-- Use relative paths like `images/screenshot.png`
-- Check file names are spelled correctly (case-sensitive!)
-
-### Config changes not appearing?
-
-- Hard refresh your browser (Ctrl+Shift+R or Cmd+Shift+R)
-- Clear browser cache
-- Make sure `config.json` is valid JSON (use a JSON validator)
-
-### Links not working?
-
-- Double-check URLs in `config.json`
-- Make sure URLs include `https://`
-- For GitHub repos, use format: `username/repository-name`
-
-## 📜 License
-
-This template is free to use for your modpack website. Customize it however you like!
-
-## 🤝 Contributing to This Template
-
-Found a bug or want to improve this template? Feel free to submit issues or pull requests!
-
----
-
-Made with ❤️ for the Minecraft modding community
+Then open `http://localhost:4173`.

--- a/config.json
+++ b/config.json
@@ -2,35 +2,35 @@
   "modpack": {
     "name": "Your Modpack Name",
     "tagline": "An Epic Adventure Awaits",
-    "description": "Embark on an unforgettable journey through a carefully crafted world of exploration and discovery. This modpack transforms Minecraft into an epic adventure filled with new dimensions, challenging dungeons, and mysterious quests.",
+    "description": "Embark on a polished Minecraft experience with curated progression, improved exploration, and long-term goals for solo and multiplayer worlds.",
     "version": "1.0.0",
     "minecraftVersion": "1.20.1"
   },
   "links": {
     "curseforge": "https://www.curseforge.com/minecraft/modpacks/your-modpack",
     "discord": "",
-    "github": "https://github.com/yourusername/modpack-wiki"
+    "github": "yourusername/modpack-wiki"
   },
   "features": [
     {
-      "title": "Epic Exploration",
-      "description": "Discover dozens of new biomes, structures, and dimensions to explore",
-      "icon": "🗺️"
+      "title": "Adventure-First Progression",
+      "description": "Questing and milestone-based progression keep players moving forward without overwhelming them.",
+      "icon": "🧭"
     },
     {
-      "title": "Challenging Combat",
-      "description": "Face powerful bosses and enhanced mobs with new weapons and armor",
+      "title": "High-Impact Combat",
+      "description": "Face tougher encounters, unique bosses, and meaningful gear upgrades.",
       "icon": "⚔️"
     },
     {
-      "title": "Quest System",
-      "description": "Follow guided questlines that lead you through the adventure",
-      "icon": "📜"
+      "title": "Worldbuilding Tools",
+      "description": "Build ambitious bases with decorative and utility mods that work well together.",
+      "icon": "🏰"
     },
     {
-      "title": "Balanced Progression",
-      "description": "Carefully tuned gameplay that rewards exploration and skill",
-      "icon": "⭐"
+      "title": "Multiplayer Friendly",
+      "description": "Balanced settings and documentation make it easier to run a shared server.",
+      "icon": "🤝"
     }
   ],
   "gallery": {
@@ -38,22 +38,22 @@
       {
         "url": "images/screenshot1.png",
         "title": "Exploring New Dimensions",
-        "description": "Venture into mysterious new worlds"
+        "description": "Venture into mysterious worlds with layered progression goals."
       },
       {
         "url": "images/screenshot2.png",
         "title": "Epic Boss Battles",
-        "description": "Face powerful enemies"
+        "description": "Take on major encounters that reward preparation and teamwork."
       },
       {
         "url": "images/screenshot3.png",
         "title": "Beautiful Landscapes",
-        "description": "Discover breathtaking biomes"
+        "description": "Discover scenic regions and biome overhauls."
       },
       {
         "url": "images/screenshot4.png",
         "title": "Ancient Structures",
-        "description": "Explore ruins and dungeons"
+        "description": "Explore dungeons, ruins, and hidden loot trails."
       }
     ]
   },
@@ -62,18 +62,40 @@
     "branch": "main",
     "categories": [
       "Getting Started",
-      "Mods List",
+      "Server Setup",
       "Progression Guide",
       "Dimensions",
       "Bosses",
       "FAQ"
+    ],
+    "pages": [
+      {
+        "title": "Quick Start",
+        "summary": "Install the pack, recommended settings, and first 30-minute goals.",
+        "file": "getting-started.md"
+      },
+      {
+        "title": "Server Admin Guide",
+        "summary": "RAM sizing, JVM flags, and moderation best practices.",
+        "file": "server-setup.md"
+      },
+      {
+        "title": "Progression Path",
+        "summary": "A phase-by-phase guide to avoid dead ends and confusion.",
+        "file": "progression-guide.md"
+      },
+      {
+        "title": "Troubleshooting",
+        "summary": "Fix common crashes, log locations, and compatibility notes.",
+        "file": "faq.md"
+      }
     ]
   },
   "theme": {
-    "primaryColor": "#d97706",
+    "primaryColor": "#f59e0b",
     "secondaryColor": "#92400e",
     "accentColor": "#fbbf24",
-    "backgroundColor": "#1c1917",
-    "textColor": "#fafaf9"
+    "backgroundColor": "#0f1116",
+    "textColor": "#f8fafc"
   }
 }

--- a/index.html
+++ b/index.html
@@ -4,141 +4,115 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title id="page-title">Modpack</title>
+    <meta name="description" content="A polished, configurable website template for Minecraft modpacks.">
     <link rel="stylesheet" href="styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Philosopher:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body>
-    <!-- Navigation -->
-    <nav class="navbar">
-        <div class="nav-container">
-            <div class="nav-logo" id="nav-logo">Modpack</div>
+    <header class="site-header">
+        <nav class="navbar container">
+            <a href="#home" class="nav-logo" id="nav-logo">Modpack</a>
             <ul class="nav-menu">
                 <li><a href="#home" class="nav-link active">Home</a></li>
+                <li><a href="#features" class="nav-link">Features</a></li>
                 <li><a href="#gallery" class="nav-link">Gallery</a></li>
                 <li><a href="#wiki" class="nav-link">Wiki</a></li>
-                <li><a href="#download" class="nav-link download-btn">Download</a></li>
+                <li><a href="#download" class="nav-link nav-cta">Download</a></li>
             </ul>
-        </div>
-    </nav>
+        </nav>
+    </header>
 
-    <!-- Hero Section -->
-    <section id="home" class="hero">
-        <div class="hero-background"></div>
-        <div class="hero-content">
+    <main>
+        <section id="home" class="hero container">
+            <p class="eyebrow">Minecraft Modpack</p>
             <h1 class="hero-title" id="hero-title">Your Modpack Name</h1>
             <p class="hero-tagline" id="hero-tagline">An Epic Adventure Awaits</p>
             <p class="hero-description" id="hero-description">Loading...</p>
-            <div class="hero-buttons">
-                <a href="#download" class="btn btn-primary" id="hero-download">
-                    <span>Download on CurseForge</span>
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-                    </svg>
-                </a>
-                <a href="#wiki" class="btn btn-secondary">
-                    <span>Read the Wiki</span>
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-                        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-                    </svg>
-                </a>
+            <div class="hero-actions">
+                <a href="#download" class="btn btn-primary" id="hero-download">Download on CurseForge</a>
+                <a href="#wiki" class="btn btn-secondary">Open Wiki Hub</a>
             </div>
             <div class="hero-stats">
-                <div class="stat">
-                    <span class="stat-value" id="mc-version">1.20.1</span>
-                    <span class="stat-label">Minecraft</span>
+                <article class="stat">
+                    <p class="stat-value" id="mc-version">1.20.1</p>
+                    <p class="stat-label">Minecraft</p>
+                </article>
+                <article class="stat">
+                    <p class="stat-value" id="pack-version">1.0.0</p>
+                    <p class="stat-label">Pack Version</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="features" class="section container">
+            <div class="section-heading">
+                <h2>Why players like this pack</h2>
+                <p>Show visitors exactly what makes your modpack special.</p>
+            </div>
+            <div class="features-grid" id="features-grid"></div>
+        </section>
+
+        <section id="gallery" class="section container">
+            <div class="section-heading">
+                <h2>Gallery</h2>
+                <p>Highlights from gameplay, builds, and community moments.</p>
+            </div>
+            <div class="gallery-grid" id="gallery-grid"></div>
+        </section>
+
+        <section id="wiki" class="section container wiki">
+            <div class="section-heading">
+                <h2>Wiki Hub</h2>
+                <p>A cleaner way to share guides, progression docs, and community knowledge.</p>
+            </div>
+
+            <div class="wiki-layout">
+                <div class="wiki-panel">
+                    <h3>Browse categories</h3>
+                    <p>These links point to markdown docs in your wiki repository.</p>
+                    <div class="wiki-categories" id="wiki-categories"></div>
                 </div>
-                <div class="stat">
-                    <span class="stat-value" id="pack-version">1.0.0</span>
-                    <span class="stat-label">Version</span>
+
+                <div class="wiki-panel">
+                    <h3>Featured pages</h3>
+                    <p>Keep this list focused on the most useful guides for new players.</p>
+                    <div class="wiki-pages" id="wiki-pages"></div>
                 </div>
             </div>
-        </div>
-        <div class="scroll-indicator">
-            <div class="scroll-arrow"></div>
-        </div>
-    </section>
 
-    <!-- Features Section -->
-    <section class="features">
-        <div class="container">
-            <h2 class="section-title">Features</h2>
-            <div class="features-grid" id="features-grid">
-                <!-- Features loaded dynamically -->
-            </div>
-        </div>
-    </section>
-
-    <!-- Gallery Section -->
-    <section id="gallery" class="gallery">
-        <div class="container">
-            <h2 class="section-title">Gallery</h2>
-            <div class="gallery-grid" id="gallery-grid">
-                <!-- Gallery loaded dynamically -->
-            </div>
-        </div>
-    </section>
-
-    <!-- Wiki Section -->
-    <section id="wiki" class="wiki">
-        <div class="container">
-            <h2 class="section-title">Community Wiki</h2>
-            <p class="wiki-intro">
-                Our wiki is community-maintained and hosted on GitHub. Anyone can contribute by submitting pull requests!
-            </p>
-            <div class="wiki-categories" id="wiki-categories">
-                <!-- Categories loaded dynamically -->
-            </div>
             <div class="wiki-contribute">
-                <h3>Want to Contribute?</h3>
-                <p>The wiki lives in our GitHub repository. Fork it, make your changes, and submit a pull request!</p>
-                <a href="#" class="btn btn-primary" id="github-link" target="_blank" rel="noopener noreferrer">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                    </svg>
-                    <span>View on GitHub</span>
-                </a>
+                <h3>Contribute to the wiki</h3>
+                <p>Fork the repo, edit markdown files, and submit a pull request. Community help keeps docs accurate.</p>
+                <a href="#" class="btn btn-primary" id="github-link" target="_blank" rel="noopener noreferrer">Open GitHub Wiki Repository</a>
             </div>
-        </div>
-    </section>
+        </section>
 
-    <!-- Download Section -->
-    <section id="download" class="download">
-        <div class="container">
-            <div class="download-content">
-                <h2 class="section-title">Ready to Start Your Adventure?</h2>
-                <p>Download the modpack from CurseForge and begin your journey today!</p>
-                <a href="#" class="btn btn-primary btn-large" id="download-btn">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
-                    </svg>
-                    <span>Download on CurseForge</span>
-                </a>
-                <div class="download-links">
-                    <a href="#" id="discord-link" class="social-link">Join Discord</a>
-                    <a href="#" id="github-wiki-link" class="social-link">GitHub Wiki</a>
-                </div>
+        <section id="download" class="section container download">
+            <h2>Ready to play?</h2>
+            <p>Install from CurseForge and jump in. Keep your wiki nearby for progression tips.</p>
+            <div class="download-actions">
+                <a href="#" class="btn btn-primary" id="download-btn">Download on CurseForge</a>
+                <a href="#" id="discord-link" class="btn btn-secondary">Join Discord</a>
+                <a href="#" id="github-wiki-link" class="btn btn-secondary">GitHub Wiki</a>
             </div>
-        </div>
-    </section>
+        </section>
+    </main>
 
-    <!-- Footer -->
     <footer class="footer">
-        <div class="container">
-            <p>Community-driven modpack. Not affiliated with Mojang or Microsoft.</p>
-            <p>Edit <code>config.json</code> to customize this website.</p>
+        <div class="container footer-inner">
+            <p>Community-driven modpack project. Not affiliated with Mojang or Microsoft.</p>
+            <p>Edit <code>config.json</code> to customize text, links, wiki pages, and colors.</p>
         </div>
     </footer>
 
-    <!-- Lightbox for Gallery -->
     <div class="lightbox" id="lightbox">
-        <button class="lightbox-close">&times;</button>
+        <button class="lightbox-close" aria-label="Close image">&times;</button>
         <img src="" alt="" id="lightbox-img">
         <div class="lightbox-caption" id="lightbox-caption"></div>
-        <button class="lightbox-prev">‹</button>
-        <button class="lightbox-next">›</button>
+        <button class="lightbox-prev" aria-label="Previous image">‹</button>
+        <button class="lightbox-next" aria-label="Next image">›</button>
     </div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,204 +1,250 @@
-// Load configuration and populate the website
 let config = {};
 let currentImageIndex = 0;
 
-// Load config.json
+const defaultFeatures = [
+    {
+        title: 'Epic Exploration',
+        description: 'Discover dozens of new biomes, structures, and dimensions to explore.',
+        icon: '🗺️'
+    },
+    {
+        title: 'Challenging Combat',
+        description: 'Face powerful bosses and enhanced mobs with new weapons and armor.',
+        icon: '⚔️'
+    },
+    {
+        title: 'Quest System',
+        description: 'Follow guided questlines that lead you through the adventure.',
+        icon: '📜'
+    },
+    {
+        title: 'Balanced Progression',
+        description: 'Carefully tuned gameplay that rewards exploration and skill.',
+        icon: '⭐'
+    }
+];
+
+const defaultGallery = [
+    {
+        url: 'https://via.placeholder.com/800x450/1f2937/fbbf24?text=Screenshot+1',
+        title: 'Add Your Screenshots',
+        description: 'Edit config.json to add your images.'
+    },
+    {
+        url: 'https://via.placeholder.com/800x450/1f2937/fbbf24?text=Screenshot+2',
+        title: 'Epic Moments',
+        description: 'Showcase your modpack gameplay.'
+    }
+];
+
+const defaultWikiCategories = [
+    'Getting Started',
+    'Mods List',
+    'Progression Guide',
+    'Dimensions',
+    'Bosses',
+    'FAQ'
+];
+
 async function loadConfig() {
     try {
         const response = await fetch('config.json');
         config = await response.json();
-        populateWebsite();
-        applyTheme();
     } catch (error) {
-        console.error('Error loading config:', error);
-        // Use default values if config fails to load
-        populateWebsite();
+        console.error('Error loading config.json:', error);
+        config = {};
     }
+
+    populateWebsite();
+    applyTheme();
 }
 
-// Populate website with config data
+function normalizeGithubRepo(repoValue) {
+    if (!repoValue) {
+        return '';
+    }
+
+    const cleaned = repoValue.trim().replace(/\.git$/, '');
+    if (cleaned.startsWith('http://') || cleaned.startsWith('https://')) {
+        const parts = cleaned.split('/').filter(Boolean);
+        const owner = parts[parts.length - 2];
+        const repo = parts[parts.length - 1];
+        return owner && repo ? `${owner}/${repo}` : '';
+    }
+
+    return cleaned.replace(/^github\.com\//, '');
+}
+
+function getGithubUrls() {
+    const fallbackRepo = normalizeGithubRepo(config.wiki?.githubRepo) || 'yourusername/modpack-wiki';
+    const linkRepo = normalizeGithubRepo(config.links?.github) || fallbackRepo;
+    const repo = linkRepo || fallbackRepo;
+    const branch = config.wiki?.branch || 'main';
+
+    return {
+        repo,
+        branch,
+        repoUrl: `https://github.com/${repo}`,
+        docsBase: `https://github.com/${repo}/blob/${branch}/wiki`
+    };
+}
+
 function populateWebsite() {
-    // Update page title and meta
-    document.getElementById('page-title').textContent = config.modpack?.name || 'Modpack';
+    document.title = config.modpack?.name || 'Modpack';
+    document.getElementById('page-title').textContent = document.title;
     document.getElementById('nav-logo').textContent = config.modpack?.name || 'Modpack';
-    
-    // Update hero section
+
     document.getElementById('hero-title').textContent = config.modpack?.name || 'Your Modpack Name';
     document.getElementById('hero-tagline').textContent = config.modpack?.tagline || 'An Epic Adventure Awaits';
-    document.getElementById('hero-description').textContent = config.modpack?.description || 'Loading...';
+    document.getElementById('hero-description').textContent = config.modpack?.description || 'Configure your modpack details in config.json.';
     document.getElementById('mc-version').textContent = config.modpack?.minecraftVersion || '1.20.1';
     document.getElementById('pack-version').textContent = config.modpack?.version || '1.0.0';
-    
-    // Update links
+
     const curseforgeUrl = config.links?.curseforge || '#';
-    const githubUrl = config.links?.github ? `https://github.com/${config.links.github}` : '#';
-    const discordUrl = config.links?.discord || '#';
-    
+    const discordUrl = config.links?.discord || '';
+    const githubUrls = getGithubUrls();
+
     document.getElementById('hero-download').href = curseforgeUrl;
     document.getElementById('download-btn').href = curseforgeUrl;
-    document.getElementById('github-link').href = githubUrl;
-    document.getElementById('github-wiki-link').href = githubUrl;
-    
-    // Update Discord link
+    document.getElementById('github-link').href = githubUrls.repoUrl;
+    document.getElementById('github-wiki-link').href = githubUrls.repoUrl;
+
     const discordLink = document.getElementById('discord-link');
-    if (discordUrl && discordUrl !== '#') {
+    if (discordUrl) {
         discordLink.href = discordUrl;
-        discordLink.style.display = 'inline-block';
+        discordLink.style.display = 'inline-flex';
     } else {
         discordLink.style.display = 'none';
     }
-    
-    // Populate features
+
     populateFeatures();
-    
-    // Populate gallery
     populateGallery();
-    
-    // Populate wiki categories
-    populateWikiCategories();
+    populateWikiHub(githubUrls);
 }
 
-// Populate features section
 function populateFeatures() {
     const featuresGrid = document.getElementById('features-grid');
+    const features = config.features?.length ? config.features : defaultFeatures;
+
     featuresGrid.innerHTML = '';
-    
-    const features = config.features || [
-        {
-            title: 'Epic Exploration',
-            description: 'Discover dozens of new biomes, structures, and dimensions to explore',
-            icon: '🗺️'
-        },
-        {
-            title: 'Challenging Combat',
-            description: 'Face powerful bosses and enhanced mobs with new weapons and armor',
-            icon: '⚔️'
-        },
-        {
-            title: 'Quest System',
-            description: 'Follow guided questlines that lead you through the adventure',
-            icon: '📜'
-        },
-        {
-            title: 'Balanced Progression',
-            description: 'Carefully tuned gameplay that rewards exploration and skill',
-            icon: '⭐'
-        }
-    ];
-    
-    features.forEach(feature => {
-        const card = document.createElement('div');
+    features.forEach((feature) => {
+        const card = document.createElement('article');
         card.className = 'feature-card';
         card.innerHTML = `
-            <span class="feature-icon">${feature.icon}</span>
-            <h3>${feature.title}</h3>
-            <p>${feature.description}</p>
+            <span class="feature-icon">${feature.icon || '✨'}</span>
+            <h3>${feature.title || 'Feature'}</h3>
+            <p>${feature.description || ''}</p>
         `;
         featuresGrid.appendChild(card);
     });
 }
 
-// Populate gallery section
 function populateGallery() {
     const galleryGrid = document.getElementById('gallery-grid');
+    const images = config.gallery?.images?.length ? config.gallery.images : defaultGallery;
+
     galleryGrid.innerHTML = '';
-    
-    const images = config.gallery?.images || [
-        {
-            url: 'https://via.placeholder.com/800x450/1c1917/fbbf24?text=Screenshot+1',
-            title: 'Add Your Screenshots',
-            description: 'Edit config.json to add your images'
-        },
-        {
-            url: 'https://via.placeholder.com/800x450/1c1917/fbbf24?text=Screenshot+2',
-            title: 'Epic Moments',
-            description: 'Showcase your modpack'
-        },
-        {
-            url: 'https://via.placeholder.com/800x450/1c1917/fbbf24?text=Screenshot+3',
-            title: 'Beautiful Scenes',
-            description: 'Capture amazing landscapes'
-        },
-        {
-            url: 'https://via.placeholder.com/800x450/1c1917/fbbf24?text=Screenshot+4',
-            title: 'Adventures',
-            description: 'Share your journey'
-        }
-    ];
-    
     images.forEach((image, index) => {
-        const item = document.createElement('div');
+        const item = document.createElement('article');
         item.className = 'gallery-item';
         item.innerHTML = `
-            <img src="${image.url}" alt="${image.title}" loading="lazy">
+            <img src="${image.url}" alt="${image.title || 'Gallery image'}" loading="lazy">
             <div class="gallery-overlay">
-                <h3>${image.title}</h3>
-                <p>${image.description}</p>
+                <h3>${image.title || 'Screenshot'}</h3>
+                <p>${image.description || ''}</p>
             </div>
         `;
+
+        const galleryImage = item.querySelector('img');
+        galleryImage.addEventListener('error', () => {
+            galleryImage.src = 'https://via.placeholder.com/800x450/1f2937/fbbf24?text=Add+Screenshot';
+        }, { once: true });
+
         item.addEventListener('click', () => openLightbox(index));
         galleryGrid.appendChild(item);
     });
 }
 
-// Populate wiki categories
-function populateWikiCategories() {
-    const wikiCategories = document.getElementById('wiki-categories');
-    wikiCategories.innerHTML = '';
-    
-    const categories = config.wiki?.categories || [
-        'Getting Started',
-        'Mods List',
-        'Progression Guide',
-        'Dimensions',
-        'Bosses',
-        'FAQ'
-    ];
-    
-    const githubRepo = config.links?.github || 'yourusername/modpack-wiki';
-    const branch = config.wiki?.branch || 'main';
-    
-    categories.forEach(category => {
+function populateWikiHub(githubUrls) {
+    const categories = config.wiki?.categories?.length ? config.wiki.categories : defaultWikiCategories;
+    const pages = config.wiki?.pages?.length
+        ? config.wiki.pages
+        : categories.slice(0, 4).map((category) => ({
+            title: category,
+            summary: `Open the ${category} documentation page.`,
+            file: `${category.toLowerCase().replace(/\s+/g, '-')}.md`
+        }));
+
+    const categoriesContainer = document.getElementById('wiki-categories');
+    const pagesContainer = document.getElementById('wiki-pages');
+
+    categoriesContainer.innerHTML = '';
+    pagesContainer.innerHTML = '';
+
+    categories.forEach((category) => {
         const categorySlug = category.toLowerCase().replace(/\s+/g, '-');
         const link = document.createElement('a');
         link.className = 'wiki-category';
-        link.href = `https://github.com/${githubRepo}/blob/${branch}/wiki/${categorySlug}.md`;
+        link.href = `${githubUrls.docsBase}/${categorySlug}.md`;
         link.target = '_blank';
         link.rel = 'noopener noreferrer';
         link.textContent = category;
-        wikiCategories.appendChild(link);
+        categoriesContainer.appendChild(link);
+    });
+
+    pages.forEach((page) => {
+        const fileName = (page.file || `${page.title || 'wiki-page'}.md`).replace(/^\//, '');
+        const pageTitle = page.title || 'Wiki Page';
+        const pageSummary = page.summary || 'Open this page in the wiki repository.';
+
+        const card = document.createElement('article');
+        card.className = 'wiki-page-card';
+        card.innerHTML = `
+            <h4>${pageTitle}</h4>
+            <p>${pageSummary}</p>
+            <a class="wiki-page-link" href="${githubUrls.docsBase}/${fileName}" target="_blank" rel="noopener noreferrer">Read page →</a>
+        `;
+        pagesContainer.appendChild(card);
     });
 }
 
-// Apply theme colors from config
 function applyTheme() {
-    if (config.theme) {
-        const root = document.documentElement;
-        if (config.theme.primaryColor) root.style.setProperty('--primary-color', config.theme.primaryColor);
-        if (config.theme.secondaryColor) root.style.setProperty('--secondary-color', config.theme.secondaryColor);
-        if (config.theme.accentColor) root.style.setProperty('--accent-color', config.theme.accentColor);
-        if (config.theme.backgroundColor) root.style.setProperty('--bg-color', config.theme.backgroundColor);
-        if (config.theme.textColor) root.style.setProperty('--text-color', config.theme.textColor);
+    if (!config.theme) {
+        return;
     }
+
+    const root = document.documentElement;
+    if (config.theme.primaryColor) root.style.setProperty('--primary-color', config.theme.primaryColor);
+    if (config.theme.secondaryColor) root.style.setProperty('--secondary-color', config.theme.secondaryColor);
+    if (config.theme.accentColor) root.style.setProperty('--accent-color', config.theme.accentColor);
+    if (config.theme.backgroundColor) root.style.setProperty('--bg-color', config.theme.backgroundColor);
+    if (config.theme.textColor) root.style.setProperty('--text-color', config.theme.textColor);
 }
 
-// Lightbox functionality
+function getGalleryImages() {
+    return config.gallery?.images?.length ? config.gallery.images : defaultGallery;
+}
+
 function openLightbox(index) {
-    const images = config.gallery?.images || [];
-    if (images.length === 0) return;
-    
+    const images = getGalleryImages();
+    if (!images.length) {
+        return;
+    }
+
     currentImageIndex = index;
+
     const lightbox = document.getElementById('lightbox');
     const lightboxImg = document.getElementById('lightbox-img');
     const lightboxCaption = document.getElementById('lightbox-caption');
-    
-    lightboxImg.src = images[currentImageIndex].url;
-    lightboxImg.alt = images[currentImageIndex].title;
+
+    const current = images[currentImageIndex];
+    lightboxImg.src = current.url;
+    lightboxImg.alt = current.title || 'Gallery image';
     lightboxCaption.innerHTML = `
-        <h3>${images[currentImageIndex].title}</h3>
-        <p>${images[currentImageIndex].description}</p>
+        <h3>${current.title || 'Screenshot'}</h3>
+        <p>${current.description || ''}</p>
     `;
-    
+
     lightbox.classList.add('active');
 }
 
@@ -207,84 +253,81 @@ function closeLightbox() {
 }
 
 function nextImage() {
-    const images = config.gallery?.images || [];
+    const images = getGalleryImages();
+    if (!images.length) {
+        return;
+    }
+
     currentImageIndex = (currentImageIndex + 1) % images.length;
     openLightbox(currentImageIndex);
 }
 
 function prevImage() {
-    const images = config.gallery?.images || [];
+    const images = getGalleryImages();
+    if (!images.length) {
+        return;
+    }
+
     currentImageIndex = (currentImageIndex - 1 + images.length) % images.length;
     openLightbox(currentImageIndex);
 }
 
-// Navigation handling
 function handleNavigation() {
     const navLinks = document.querySelectorAll('.nav-link');
     const sections = document.querySelectorAll('section[id]');
-    
-    // Smooth scroll for navigation links
-    navLinks.forEach(link => {
-        link.addEventListener('click', (e) => {
+
+    navLinks.forEach((link) => {
+        link.addEventListener('click', (event) => {
             const href = link.getAttribute('href');
-            if (href && href.startsWith('#')) {
-                e.preventDefault();
-                const target = document.querySelector(href);
-                if (target) {
-                    target.scrollIntoView({ behavior: 'smooth' });
-                    
-                    // Update active link
-                    navLinks.forEach(l => l.classList.remove('active'));
-                    link.classList.add('active');
-                }
+            if (!href || !href.startsWith('#')) {
+                return;
+            }
+
+            event.preventDefault();
+            const target = document.querySelector(href);
+            if (target) {
+                target.scrollIntoView({ behavior: 'smooth' });
             }
         });
     });
-    
-    // Update active nav on scroll
+
     window.addEventListener('scroll', () => {
-        let current = '';
-        sections.forEach(section => {
-            const sectionTop = section.offsetTop;
-            const sectionHeight = section.clientHeight;
-            if (window.pageYOffset >= sectionTop - 100) {
-                current = section.getAttribute('id');
+        let currentSectionId = 'home';
+
+        sections.forEach((section) => {
+            if (window.scrollY >= section.offsetTop - 140) {
+                currentSectionId = section.id;
             }
         });
-        
-        navLinks.forEach(link => {
-            link.classList.remove('active');
-            if (link.getAttribute('href') === `#${current}`) {
-                link.classList.add('active');
-            }
+
+        navLinks.forEach((link) => {
+            link.classList.toggle('active', link.getAttribute('href') === `#${currentSectionId}`);
         });
     });
 }
 
-// Event listeners
 document.addEventListener('DOMContentLoaded', () => {
     loadConfig();
     handleNavigation();
-    
-    // Lightbox controls
+
     document.querySelector('.lightbox-close').addEventListener('click', closeLightbox);
     document.querySelector('.lightbox-next').addEventListener('click', nextImage);
     document.querySelector('.lightbox-prev').addEventListener('click', prevImage);
-    
-    // Close lightbox on background click
-    document.getElementById('lightbox').addEventListener('click', (e) => {
-        if (e.target.id === 'lightbox') {
+
+    document.getElementById('lightbox').addEventListener('click', (event) => {
+        if (event.target.id === 'lightbox') {
             closeLightbox();
         }
     });
-    
-    // Keyboard navigation for lightbox
-    document.addEventListener('keydown', (e) => {
-        const lightbox = document.getElementById('lightbox');
-        if (lightbox.classList.contains('active')) {
-            if (e.key === 'Escape') closeLightbox();
-            if (e.key === 'ArrowRight') nextImage();
-            if (e.key === 'ArrowLeft') prevImage();
+
+    document.addEventListener('keydown', (event) => {
+        const isLightboxOpen = document.getElementById('lightbox').classList.contains('active');
+        if (!isLightboxOpen) {
+            return;
         }
+
+        if (event.key === 'Escape') closeLightbox();
+        if (event.key === 'ArrowRight') nextImage();
+        if (event.key === 'ArrowLeft') prevImage();
     });
 });

--- a/styles.css
+++ b/styles.css
@@ -1,623 +1,460 @@
 :root {
     --primary-color: #d97706;
-    --secondary-color: #92400e;
+    --secondary-color: #78350f;
     --accent-color: #fbbf24;
-    --bg-color: #1c1917;
-    --text-color: #fafaf9;
-    --card-bg: #292524;
-    --border-color: #44403c;
+    --bg-color: #0f1116;
+    --surface-color: #151923;
+    --surface-soft: #1c2230;
+    --text-color: #f8fafc;
+    --muted-text: #cbd5e1;
+    --border-color: #2a3344;
+    --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 * {
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
-    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
 }
 
 body {
-    font-family: 'Philosopher', sans-serif;
-    background-color: var(--bg-color);
-    color: var(--text-color);
+    font-family: 'Inter', sans-serif;
     line-height: 1.6;
-    overflow-x: hidden;
+    background: radial-gradient(circle at top, #1e2433 0%, var(--bg-color) 45%);
+    color: var(--text-color);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.container {
+    width: min(1120px, 92vw);
+    margin-inline: auto;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+    backdrop-filter: blur(8px);
+    background: rgba(15, 17, 22, 0.82);
 }
 
 .navbar {
-    position: fixed;
-    top: 0;
-    width: 100%;
-    background: rgba(28, 25, 23, 0.95);
-    backdrop-filter: blur(10px);
-    z-index: 1000;
-    border-bottom: 2px solid var(--border-color);
-}
-
-.nav-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 1rem 2rem;
+    min-height: 72px;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 1.5rem;
 }
 
 .nav-logo {
-    font-family: 'Cinzel', serif;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--accent-color);
-    text-shadow: 0 0 20px rgba(251, 191, 36, 0.5);
+    font-size: 1.1rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
 }
 
 .nav-menu {
-    display: flex;
     list-style: none;
-    gap: 2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .nav-link {
+    display: inline-block;
+    color: var(--muted-text);
+    font-weight: 600;
+    font-size: 0.95rem;
+    padding: 0.5rem 0.85rem;
+    border-radius: 999px;
+    transition: 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
     color: var(--text-color);
-    text-decoration: none;
-    font-weight: 500;
-    transition: all 0.3s ease;
-    position: relative;
-    padding: 0.5rem 0;
+    background: rgba(251, 191, 36, 0.1);
 }
 
-.nav-link::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 0;
-    height: 2px;
+.nav-cta {
+    background: var(--primary-color);
+    color: #1a1200;
+}
+
+.nav-cta:hover,
+.nav-cta.active {
     background: var(--accent-color);
-    transition: width 0.3s ease;
-}
-
-.nav-link:hover::after,
-.nav-link.active::after {
-    width: 100%;
-}
-
-.nav-link.download-btn {
-    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
-    padding: 0.5rem 1.5rem;
-    border-radius: 8px;
-    border: 1px solid var(--accent-color);
-}
-
-.nav-link.download-btn::after {
-    display: none;
+    color: #1a1200;
 }
 
 .hero {
-    position: relative;
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    padding: 2rem;
-    overflow: hidden;
+    padding: 5rem 0 2.5rem;
 }
 
-.hero-background {
-    position: absolute;
-    inset: 0;
-    background: 
-        radial-gradient(circle at 20% 50%, rgba(217, 119, 6, 0.1) 0%, transparent 50%),
-        radial-gradient(circle at 80% 50%, rgba(146, 64, 14, 0.1) 0%, transparent 50%),
-        linear-gradient(180deg, var(--bg-color) 0%, #0c0a09 100%);
-    animation: pulse 8s ease-in-out infinite;
-}
-
-@keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.8; }
-}
-
-.hero-content {
-    position: relative;
-    z-index: 1;
-    max-width: 900px;
-    animation: fadeInUp 1s ease-out;
-}
-
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(30px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+.eyebrow {
+    color: var(--accent-color);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.76rem;
+    font-weight: 700;
+    margin-bottom: 0.8rem;
 }
 
 .hero-title {
-    font-family: 'Cinzel', serif;
-    font-size: clamp(2.5rem, 6vw, 5rem);
-    font-weight: 700;
-    margin-bottom: 1rem;
-    background: linear-gradient(135deg, var(--accent-color), var(--primary-color));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    animation: titleGlow 3s ease-in-out infinite;
-}
-
-@keyframes titleGlow {
-    0%, 100% { filter: drop-shadow(0 0 20px rgba(251, 191, 36, 0.4)); }
-    50% { filter: drop-shadow(0 0 40px rgba(251, 191, 36, 0.6)); }
+    font-size: clamp(2rem, 5vw, 3.25rem);
+    line-height: 1.15;
+    margin-bottom: 0.6rem;
 }
 
 .hero-tagline {
-    font-size: 1.5rem;
+    font-size: clamp(1rem, 2.1vw, 1.25rem);
     color: var(--accent-color);
-    margin-bottom: 1.5rem;
-    opacity: 0;
-    animation: fadeIn 1s ease-out 0.3s forwards;
-}
-
-@keyframes fadeIn {
-    to { opacity: 1; }
+    margin-bottom: 0.9rem;
+    font-weight: 600;
 }
 
 .hero-description {
-    font-size: 1.1rem;
-    color: #d6d3d1;
-    margin-bottom: 2rem;
-    max-width: 700px;
-    margin-left: auto;
-    margin-right: auto;
-    opacity: 0;
-    animation: fadeIn 1s ease-out 0.6s forwards;
+    max-width: 68ch;
+    color: var(--muted-text);
 }
 
-.hero-buttons {
+.hero-actions,
+.download-actions {
     display: flex;
-    gap: 1rem;
-    justify-content: center;
     flex-wrap: wrap;
-    margin-bottom: 3rem;
-    opacity: 0;
-    animation: fadeIn 1s ease-out 0.9s forwards;
+    gap: 0.75rem;
+    margin-top: 1.4rem;
 }
 
 .btn {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.5rem;
-    padding: 1rem 2rem;
-    border-radius: 12px;
-    text-decoration: none;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    border: 2px solid transparent;
-    cursor: pointer;
+    font-weight: 700;
+    border: 1px solid transparent;
+    border-radius: 0.8rem;
+    padding: 0.72rem 1rem;
+    transition: 0.2s ease;
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
-    color: var(--text-color);
-    border-color: var(--accent-color);
-    box-shadow: 0 4px 20px rgba(217, 119, 6, 0.3);
+    background: linear-gradient(120deg, var(--primary-color), var(--accent-color));
+    color: #1a1200;
 }
 
 .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 30px rgba(217, 119, 6, 0.5);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow);
 }
 
 .btn-secondary {
-    background: rgba(68, 64, 60, 0.5);
-    color: var(--text-color);
     border-color: var(--border-color);
+    background: var(--surface-color);
+    color: var(--text-color);
 }
 
 .btn-secondary:hover {
-    background: rgba(68, 64, 60, 0.8);
     border-color: var(--accent-color);
 }
 
-.btn-large {
-    font-size: 1.2rem;
-    padding: 1.25rem 2.5rem;
-}
-
 .hero-stats {
-    display: flex;
-    gap: 3rem;
-    justify-content: center;
-    opacity: 0;
-    animation: fadeIn 1s ease-out 1.2s forwards;
+    margin-top: 1.8rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 0.8rem;
 }
 
 .stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    background: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0.95rem;
+    padding: 1rem;
 }
 
 .stat-value {
-    font-family: 'Cinzel', serif;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--accent-color);
+    font-size: 1.25rem;
+    font-weight: 800;
 }
 
 .stat-label {
     font-size: 0.9rem;
-    color: #a8a29e;
+    color: var(--muted-text);
 }
 
-.scroll-indicator {
-    position: absolute;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    animation: bounce 2s infinite;
+.section {
+    padding: 2.4rem 0;
 }
 
-@keyframes bounce {
-    0%, 20%, 50%, 80%, 100% { transform: translateX(-50%) translateY(0); }
-    40% { transform: translateX(-50%) translateY(-10px); }
-    60% { transform: translateX(-50%) translateY(-5px); }
+.section-heading h2 {
+    font-size: clamp(1.45rem, 2.8vw, 2rem);
+    margin-bottom: 0.35rem;
 }
 
-.scroll-arrow {
-    width: 30px;
-    height: 30px;
-    border-bottom: 2px solid var(--accent-color);
-    border-right: 2px solid var(--accent-color);
-    transform: rotate(45deg);
+.section-heading p {
+    color: var(--muted-text);
 }
 
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 4rem 2rem;
-}
-
-.section-title {
-    font-family: 'Cinzel', serif;
-    font-size: clamp(2rem, 4vw, 3rem);
-    text-align: center;
-    margin-bottom: 3rem;
-    color: var(--accent-color);
-    position: relative;
-}
-
-.section-title::after {
-    content: '';
-    display: block;
-    width: 100px;
-    height: 3px;
-    background: linear-gradient(90deg, transparent, var(--accent-color), transparent);
-    margin: 1rem auto 0;
-}
-
-.features {
-    background: linear-gradient(180deg, var(--bg-color), #0c0a09);
-    position: relative;
-}
-
-.features-grid {
+.features-grid,
+.gallery-grid {
+    margin-top: 1.2rem;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 1rem;
+}
+
+.feature-card,
+.gallery-item,
+.wiki-panel,
+.wiki-contribute,
+.wiki-page-card {
+    background: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
 }
 
 .feature-card {
-    background: var(--card-bg);
-    padding: 2rem;
-    border-radius: 16px;
-    border: 2px solid var(--border-color);
-    transition: all 0.3s ease;
-    position: relative;
-    overflow: hidden;
-}
-
-.feature-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
-    transform: scaleX(0);
-    transition: transform 0.3s ease;
-}
-
-.feature-card:hover::before {
-    transform: scaleX(1);
-}
-
-.feature-card:hover {
-    transform: translateY(-5px);
-    border-color: var(--accent-color);
-    box-shadow: 0 10px 40px rgba(217, 119, 6, 0.2);
+    padding: 1rem;
 }
 
 .feature-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-    display: block;
+    font-size: 1.5rem;
+    display: inline-block;
+    margin-bottom: 0.5rem;
 }
 
 .feature-card h3 {
-    font-family: 'Cinzel', serif;
-    font-size: 1.5rem;
-    margin-bottom: 0.5rem;
-    color: var(--accent-color);
+    margin-bottom: 0.4rem;
+    font-size: 1.05rem;
 }
 
 .feature-card p {
-    color: #d6d3d1;
-}
-
-.gallery {
-    background: #0c0a09;
-}
-
-.gallery-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1.5rem;
+    color: var(--muted-text);
+    font-size: 0.95rem;
 }
 
 .gallery-item {
-    position: relative;
     overflow: hidden;
-    border-radius: 12px;
+    position: relative;
     cursor: pointer;
-    aspect-ratio: 16/9;
-    background: var(--card-bg);
 }
 
 .gallery-item img {
     width: 100%;
-    height: 100%;
+    height: 220px;
     object-fit: cover;
-    transition: transform 0.5s ease;
+    display: block;
+    transition: transform 0.3s ease;
 }
 
 .gallery-item:hover img {
-    transform: scale(1.1);
+    transform: scale(1.04);
 }
 
 .gallery-overlay {
     position: absolute;
-    inset: 0;
-    background: linear-gradient(to top, rgba(0,0,0,0.9), transparent);
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    padding: 1.5rem;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.gallery-item:hover .gallery-overlay {
-    opacity: 1;
+    inset: auto 0 0;
+    padding: 0.8rem;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.8), transparent);
 }
 
 .gallery-overlay h3 {
-    font-family: 'Cinzel', serif;
-    color: var(--accent-color);
-    margin-bottom: 0.25rem;
+    font-size: 0.98rem;
 }
 
 .gallery-overlay p {
-    color: #d6d3d1;
+    color: #d1d5db;
+    font-size: 0.84rem;
+}
+
+.wiki-layout {
+    margin-top: 1.2rem;
+    display: grid;
+    grid-template-columns: 1fr 1.3fr;
+    gap: 1rem;
+}
+
+.wiki-panel,
+.wiki-contribute {
+    padding: 1rem;
+}
+
+.wiki-panel > p,
+.wiki-contribute > p {
+    color: var(--muted-text);
+    margin: 0.35rem 0 0.9rem;
+}
+
+.wiki-categories,
+.wiki-pages {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.wiki-category {
+    background: var(--surface-soft);
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    padding: 0.65rem 0.8rem;
+    font-weight: 600;
+    font-size: 0.92rem;
+    transition: 0.2s ease;
+}
+
+.wiki-category:hover {
+    border-color: var(--accent-color);
+    transform: translateX(2px);
+}
+
+.wiki-page-card {
+    padding: 0.9rem;
+}
+
+.wiki-page-card h4 {
+    margin-bottom: 0.25rem;
+}
+
+.wiki-page-card p {
+    color: var(--muted-text);
+    font-size: 0.92rem;
+    margin-bottom: 0.65rem;
+}
+
+.wiki-page-link {
+    color: var(--accent-color);
+    font-weight: 700;
     font-size: 0.9rem;
 }
 
+.wiki-contribute {
+    margin-top: 1rem;
+}
+
+.download {
+    text-align: center;
+    background: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    margin-bottom: 3rem;
+}
+
+.download p {
+    color: var(--muted-text);
+    margin-top: 0.35rem;
+}
+
+.download-actions {
+    justify-content: center;
+}
+
+.footer {
+    padding: 1.4rem 0 2rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.footer-inner {
+    color: #94a3b8;
+    font-size: 0.9rem;
+    display: grid;
+    gap: 0.25rem;
+}
+
 .lightbox {
-    display: none;
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.95);
-    z-index: 2000;
-    justify-content: center;
+    background: rgba(0, 0, 0, 0.88);
+    display: none;
     align-items: center;
+    justify-content: center;
+    z-index: 60;
 }
 
 .lightbox.active {
     display: flex;
 }
 
-.lightbox img {
-    max-width: 90%;
-    max-height: 80vh;
-    border-radius: 8px;
+#lightbox-img {
+    max-width: min(90vw, 1100px);
+    max-height: 75vh;
+    border-radius: 0.7rem;
+}
+
+.lightbox-caption {
+    position: absolute;
+    bottom: 8%;
+    left: 50%;
+    transform: translateX(-50%);
+    text-align: center;
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid var(--border-color);
+    padding: 0.7rem 0.9rem;
+    border-radius: 0.7rem;
 }
 
 .lightbox-close,
 .lightbox-prev,
 .lightbox-next {
     position: absolute;
-    background: rgba(217, 119, 6, 0.8);
     border: none;
     color: white;
-    font-size: 2rem;
+    background: rgba(15, 23, 42, 0.65);
+    width: 2.4rem;
+    height: 2.4rem;
+    border-radius: 999px;
+    font-size: 1.5rem;
     cursor: pointer;
-    padding: 1rem;
-    transition: background 0.3s ease;
-    border-radius: 8px;
-}
-
-.lightbox-close:hover,
-.lightbox-prev:hover,
-.lightbox-next:hover {
-    background: var(--primary-color);
 }
 
 .lightbox-close {
-    top: 2rem;
-    right: 2rem;
+    top: 2.5rem;
+    right: 2.5rem;
 }
 
 .lightbox-prev {
-    left: 2rem;
-    top: 50%;
-    transform: translateY(-50%);
+    left: 1.25rem;
 }
 
 .lightbox-next {
-    right: 2rem;
-    top: 50%;
-    transform: translateY(-50%);
+    right: 1.25rem;
 }
 
-.lightbox-caption {
-    position: absolute;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    text-align: center;
-    color: white;
-    background: rgba(0, 0, 0, 0.7);
-    padding: 1rem 2rem;
-    border-radius: 8px;
-}
-
-.wiki {
-    background: linear-gradient(180deg, #0c0a09, var(--bg-color));
-}
-
-.wiki-intro {
-    text-align: center;
-    max-width: 700px;
-    margin: 0 auto 3rem;
-    color: #d6d3d1;
-    font-size: 1.1rem;
-}
-
-.wiki-categories {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    margin-bottom: 3rem;
-}
-
-.wiki-category {
-    background: var(--card-bg);
-    padding: 1.5rem;
-    border-radius: 12px;
-    border: 2px solid var(--border-color);
-    text-align: center;
-    text-decoration: none;
-    color: var(--text-color);
-    font-weight: 600;
-    transition: all 0.3s ease;
-}
-
-.wiki-category:hover {
-    border-color: var(--accent-color);
-    transform: translateY(-3px);
-    box-shadow: 0 5px 20px rgba(217, 119, 6, 0.2);
-}
-
-.wiki-contribute {
-    background: var(--card-bg);
-    padding: 3rem;
-    border-radius: 16px;
-    border: 2px solid var(--border-color);
-    text-align: center;
-}
-
-.wiki-contribute h3 {
-    font-family: 'Cinzel', serif;
-    font-size: 2rem;
-    color: var(--accent-color);
-    margin-bottom: 1rem;
-}
-
-.wiki-contribute p {
-    color: #d6d3d1;
-    margin-bottom: 2rem;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.download {
-    background: linear-gradient(135deg, #0c0a09, var(--bg-color));
-    border-top: 2px solid var(--border-color);
-    border-bottom: 2px solid var(--border-color);
-}
-
-.download-content {
-    text-align: center;
-}
-
-.download-content p {
-    color: #d6d3d1;
-    font-size: 1.2rem;
-    margin-bottom: 2rem;
-}
-
-.download-links {
-    display: flex;
-    gap: 2rem;
-    justify-content: center;
-    margin-top: 2rem;
-}
-
-.social-link {
-    color: var(--accent-color);
-    text-decoration: none;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    padding: 0.5rem 1rem;
-    border-bottom: 2px solid transparent;
-}
-
-.social-link:hover {
-    border-bottom-color: var(--accent-color);
-}
-
-.footer {
-    background: #0c0a09;
-    padding: 2rem;
-    text-align: center;
-    color: #a8a29e;
-    border-top: 2px solid var(--border-color);
-}
-
-.footer p {
-    margin: 0.5rem 0;
-}
-
-.footer code {
-    background: var(--card-bg);
-    padding: 0.2rem 0.5rem;
-    border-radius: 4px;
-    color: var(--accent-color);
-}
-
-@media (max-width: 768px) {
-    .nav-menu {
-        gap: 1rem;
-        font-size: 0.9rem;
+@media (max-width: 860px) {
+    .wiki-layout {
+        grid-template-columns: 1fr;
     }
-    
-    .hero-buttons {
+
+    .navbar {
         flex-direction: column;
-        align-items: center;
+        justify-content: center;
+        padding: 0.85rem 0;
     }
-    
-    .btn {
-        width: 100%;
-        max-width: 300px;
+
+    .nav-menu {
         justify-content: center;
     }
-    
-    .lightbox-prev,
-    .lightbox-next {
-        display: none;
+}
+
+@media (max-width: 560px) {
+    .hero {
+        padding-top: 4rem;
+    }
+
+    .gallery-item img {
+        height: 190px;
+    }
+
+    .lightbox-caption {
+        width: 88vw;
+        bottom: 5%;
     }
 }


### PR DESCRIPTION
### Motivation
- Make the site look cleaner and more modern with improved typography, spacing and clear CTAs so visitors can quickly understand the modpack.
- Provide a simple community-editable Wiki surface so docs are discoverable from the site and easy for contributors to edit on GitHub.
- Enable one-click deployment via GitHub Pages so the static site can be published from the `main` branch using Actions.

### Description
- Redesigned layout and visuals: replaced `index.html` and `styles.css` with a simplified header, hero, features, gallery, dedicated `Wiki Hub`, card-based components and responsive styling; switched fonts to `Inter` for a cleaner UI. Files: `index.html`, `styles.css`.
- Frontend refactor: rewrote `script.js` to load `config.json` robustly, normalize GitHub repo values (accepts `owner/repo` or full URL), generate wiki category links and featured wiki page cards, provide safe defaults, and add gallery image `error` fallback to a placeholder. Key functions: `loadConfig()`, `normalizeGithubRepo()`, `getGithubUrls()`, `populateWikiHub()`, `applyTheme()`.
- Updated defaults and wiki integration: improved `config.json` sample content and added `wiki.pages` entries so the Wiki Hub is useful out of the box; links are generated pointing to `https://github.com/<repo>/blob/<branch>/wiki/<file>.md`.
- Added GitHub Pages CI workflow: `.github/workflows/deploy-pages.yml` uses official Pages actions to upload and deploy the repository on pushes to `main` or via `workflow_dispatch`.
- Documentation: condensed and clarified `README.md` with quick start, configuration fields, wiki file link behavior and local preview instructions.

### Testing
- Ran `node --check script.js` to validate the JS syntax; the check completed successfully.
- Validated JSON with a small Python check: `python3 - <<'PY' import json; json.load(open('config.json'))` which completed and printed success, confirming `config.json` is valid.
- Started a local static server with `python3 -m http.server 4173` and captured a full-page screenshot via Playwright to verify layout; screenshot artifact was produced (clean-site-full.png). The server served pages successfully.
- Observed expected 404s for example image paths because `images/` screenshots are not included in the repo; the site now falls back to placeholder images when an image `error` occurs (behavior validated during local testing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd15f81d0832890974bbde04f2a4c)