### PR TITLE
Add configurable Blog section to the modpack website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A clean, configurable static website for Minecraft modpacks with:
 - polished landing page
 - gallery with lightbox
 - wiki hub (categories + featured pages)
+- blog section for news, patch notes, and updates
 - GitHub Pages deployment workflow
 
 ## Quick Start
@@ -23,6 +24,7 @@ Everything is controlled through `config.json`.
 - `links.curseforge`: download link
 - `links.discord`: optional community invite
 - `links.github`: either `owner/repo` or full GitHub URL
+- `blog.posts`: list of blog cards (title, summary, date, author, url)
 - `wiki.categories`: category chips shown in the wiki hub
 - `wiki.pages`: featured wiki cards with title, summary, and markdown file
 - `theme`: color overrides

--- a/config.json
+++ b/config.json
@@ -15,22 +15,22 @@
     {
       "title": "Adventure-First Progression",
       "description": "Questing and milestone-based progression keep players moving forward without overwhelming them.",
-      "icon": "🧭"
+      "icon": "\ud83e\udded"
     },
     {
       "title": "High-Impact Combat",
       "description": "Face tougher encounters, unique bosses, and meaningful gear upgrades.",
-      "icon": "⚔️"
+      "icon": "\u2694\ufe0f"
     },
     {
       "title": "Worldbuilding Tools",
       "description": "Build ambitious bases with decorative and utility mods that work well together.",
-      "icon": "🏰"
+      "icon": "\ud83c\udff0"
     },
     {
       "title": "Multiplayer Friendly",
       "description": "Balanced settings and documentation make it easier to run a shared server.",
-      "icon": "🤝"
+      "icon": "\ud83e\udd1d"
     }
   ],
   "gallery": {
@@ -97,5 +97,30 @@
     "accentColor": "#fbbf24",
     "backgroundColor": "#0f1116",
     "textColor": "#f8fafc"
+  },
+  "blog": {
+    "posts": [
+      {
+        "title": "v1.0 Release Notes",
+        "summary": "Highlights from launch week, progression changes, and top-reported fixes.",
+        "date": "2026-01-15",
+        "author": "Your Name",
+        "url": "https://example.com/blog/v1-0-release-notes"
+      },
+      {
+        "title": "Server Performance Guide",
+        "summary": "Suggested flags, pregeneration tips, and chunk loading rules for smoother worlds.",
+        "date": "2026-01-08",
+        "author": "Server Team",
+        "url": "https://example.com/blog/server-performance-guide"
+      },
+      {
+        "title": "Community Spotlight",
+        "summary": "Featured player builds, event recap, and what is coming next in the roadmap.",
+        "date": "2025-12-28",
+        "author": "Community Manager",
+        "url": "https://example.com/blog/community-spotlight"
+      }
+    ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
                 <li><a href="#home" class="nav-link active">Home</a></li>
                 <li><a href="#features" class="nav-link">Features</a></li>
                 <li><a href="#gallery" class="nav-link">Gallery</a></li>
+                <li><a href="#blog" class="nav-link">Blog</a></li>
                 <li><a href="#wiki" class="nav-link">Wiki</a></li>
                 <li><a href="#download" class="nav-link nav-cta">Download</a></li>
             </ul>
@@ -60,6 +61,14 @@
                 <p>Highlights from gameplay, builds, and community moments.</p>
             </div>
             <div class="gallery-grid" id="gallery-grid"></div>
+        </section>
+
+        <section id="blog" class="section container">
+            <div class="section-heading">
+                <h2>Blog</h2>
+                <p>Share patch notes, development updates, and community highlights.</p>
+            </div>
+            <div class="blog-grid" id="blog-grid"></div>
         </section>
 
         <section id="wiki" class="section container wiki">

--- a/script.js
+++ b/script.js
@@ -37,6 +37,31 @@ const defaultGallery = [
     }
 ];
 
+
+const defaultBlogPosts = [
+    {
+        title: 'Version 1.0.0 Released',
+        summary: 'Your first stable release is live with curated progression, performance tuning, and updated quest flow.',
+        date: '2026-01-15',
+        author: 'Modpack Team',
+        url: '#'
+    },
+    {
+        title: 'Server Setup Tips',
+        summary: 'Recommended JVM settings, backup strategy, and early anti-lag config suggestions for multiplayer worlds.',
+        date: '2026-01-02',
+        author: 'Ops Lead',
+        url: '#'
+    },
+    {
+        title: 'Roadmap: Next Content Phase',
+        summary: 'A look at upcoming dimensions, progression gates, and planned quality-of-life updates.',
+        date: '2025-12-20',
+        author: 'Design Team',
+        url: '#'
+    }
+];
+
 const defaultWikiCategories = [
     'Getting Started',
     'Mods List',
@@ -119,6 +144,7 @@ function populateWebsite() {
 
     populateFeatures();
     populateGallery();
+    populateBlogPosts();
     populateWikiHub(githubUrls);
 }
 
@@ -162,6 +188,55 @@ function populateGallery() {
 
         item.addEventListener('click', () => openLightbox(index));
         galleryGrid.appendChild(item);
+    });
+}
+
+
+function formatBlogDate(value) {
+    if (!value) {
+        return 'Recent update';
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return value;
+    }
+
+    return parsed.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+    });
+}
+
+function populateBlogPosts() {
+    const blogGrid = document.getElementById('blog-grid');
+    if (!blogGrid) {
+        return;
+    }
+
+    const posts = config.blog?.posts?.length ? config.blog.posts : defaultBlogPosts;
+    blogGrid.innerHTML = '';
+
+    posts.forEach((post) => {
+        const article = document.createElement('article');
+        article.className = 'blog-card';
+
+        const postTitle = post.title || 'Blog Post';
+        const postSummary = post.summary || 'Share an update with your community.';
+        const postAuthor = post.author || 'Modpack Team';
+        const postUrl = post.url || '#';
+
+        article.innerHTML = `
+            <p class="blog-meta">${formatBlogDate(post.date)} · ${postAuthor}</p>
+            <h3>${postTitle}</h3>
+            <p>${postSummary}</p>
+            <a class="blog-link" href="${postUrl}" ${postUrl === '#' ? '' : 'target="_blank" rel="noopener noreferrer"'}>
+                Read update →
+            </a>
+        `;
+
+        blogGrid.appendChild(article);
     });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -206,7 +206,8 @@ a {
 }
 
 .features-grid,
-.gallery-grid {
+.gallery-grid,
+.blog-grid {
     margin-top: 1.2rem;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
@@ -241,6 +242,41 @@ a {
 .feature-card p {
     color: var(--muted-text);
     font-size: 0.95rem;
+}
+
+
+.blog-card {
+    background: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.blog-meta {
+    color: var(--accent-color);
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.blog-card h3 {
+    font-size: 1.08rem;
+}
+
+.blog-card p {
+    color: var(--muted-text);
+}
+
+.blog-link {
+    color: var(--text-color);
+    font-weight: 700;
+    margin-top: auto;
+}
+
+.blog-link:hover {
+    color: var(--accent-color);
 }
 
 .gallery-item {


### PR DESCRIPTION
### Motivation
- Provide a simple, configurable Blog area so pack maintainers can share patch notes, development updates, and community highlights directly on the homepage.

### Description
- Added a `Blog` navigation link and a new blog section markup (`#blog`) to `index.html` so visitors can jump to updates.
- Implemented `defaultBlogPosts`, `formatBlogDate`, and `populateBlogPosts()` in `script.js`, and wired the blog rendering into the existing `populateWebsite()` flow with safe fallbacks to configuration.
- Added blog card styles and responsive grid rules in `styles.css` to match the existing site visual system (`.blog-grid`, `.blog-card`, `.blog-meta`, `.blog-link`).
- Extended `config.json` with an example `blog.posts` block and updated `README.md` to document the new `blog.posts` configuration field.

### Testing
- Ran `node --check script.js` to validate the modified JavaScript (passed).
- Validated `config.json` with `python3 -m json.tool config.json` (passed).
- Launched a local preview with `python3 -m http.server 4173` and captured an automated browser screenshot of the blog section using Playwright, confirming the blog cards render; screenshot artifact: `browser:/tmp/codex_browser_invocations/8bae311a805e0165/artifacts/artifacts/blog-section.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699600e33504832888e55e7a3373057f)