### PR TITLE
Add configurable site logo and folder-based blog posts with image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
 A clean, configurable static website for Minecraft modpacks with:
 
 - polished landing page
+- configurable text or image logo
 - gallery with lightbox
+- file-based blog system (with local post images)
 - wiki hub (categories + featured pages)
-- blog section for news, patch notes, and updates
 - GitHub Pages deployment workflow
 
 ## Quick Start
 
 1. Edit `config.json` with your modpack details and links.
 2. Add screenshots to `images/` and reference them in `config.json`.
-3. Push to GitHub and enable Pages (workflow included).
+3. Add blog posts inside the `blogs/` folder.
+4. Push to GitHub and enable Pages (workflow included).
 
 ## Configuration
 
@@ -21,15 +23,54 @@ Everything is controlled through `config.json`.
 ### Important fields
 
 - `modpack`: website title, tagline, description, versions
+- `branding.logo`: optional navbar logo image (path, alt text, width, height)
 - `links.curseforge`: download link
 - `links.discord`: optional community invite
 - `links.github`: either `owner/repo` or full GitHub URL
-- `blog.posts`: list of blog cards (title, summary, date, author, url)
+- `blog.source`: set to `"folder"` to load posts from files
+- `blog.indexFile`: index file listing blog JSON files (default `blogs/index.json`)
 - `wiki.categories`: category chips shown in the wiki hub
 - `wiki.pages`: featured wiki cards with title, summary, and markdown file
 - `theme`: color overrides
 
-### Wiki file links
+## Blog folder format
+
+The blog system loads files from `blogs/index.json`:
+
+```json
+{
+  "posts": [
+    { "file": "blogs/example-launch-update.json" }
+  ]
+}
+```
+
+Each blog JSON file can include:
+
+```json
+{
+  "title": "Example Blog",
+  "summary": "Short preview text",
+  "date": "2026-02-10",
+  "author": "Modpack Team",
+  "coverImage": "blogs/images/example-cover.png",
+  "content": [
+    { "type": "paragraph", "text": "Intro paragraph" },
+    { "type": "heading", "text": "Patch Highlights" },
+    { "type": "list", "items": ["Added quests", "Balanced mobs"] },
+    {
+      "type": "image",
+      "src": "blogs/images/patch-1-screenshot.png",
+      "alt": "New biome",
+      "caption": "Put blog images in blogs/images"
+    }
+  ]
+}
+```
+
+> You can copy `blogs/example-launch-update.json` as a template for new posts.
+
+## Wiki file links
 
 Wiki links are generated as:
 

--- a/blogs/example-launch-update.json
+++ b/blogs/example-launch-update.json
@@ -1,0 +1,35 @@
+{
+  "title": "Example Blog: v1.0 Launch Update",
+  "summary": "This example shows how to write a local blog post with headings, lists, and images stored in the blogs folder.",
+  "date": "2026-02-10",
+  "author": "Modpack Team",
+  "coverImage": "blogs/images/example-cover.svg",
+  "content": [
+    {
+      "type": "paragraph",
+      "text": "Welcome to the first update post. This post is loaded from blogs/example-launch-update.json so your site can keep blog content in files."
+    },
+    {
+      "type": "heading",
+      "text": "What was added"
+    },
+    {
+      "type": "list",
+      "items": [
+        "A file-based blog folder system",
+        "Support for cover images per post",
+        "Inline blog images and captions"
+      ]
+    },
+    {
+      "type": "image",
+      "src": "blogs/images/example-inline.svg",
+      "alt": "Example in-blog image",
+      "caption": "Place your screenshots in blogs/images and reference them with relative paths."
+    },
+    {
+      "type": "paragraph",
+      "text": "To add another post, copy this JSON file, change the text/images, and add the file path to blogs/index.json."
+    }
+  ]
+}

--- a/blogs/images/example-cover.svg
+++ b/blogs/images/example-cover.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="Example blog cover">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <text x="80" y="260" fill="#fbbf24" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="700">Example Blog Cover</text>
+  <text x="80" y="340" fill="#e2e8f0" font-family="Inter, Arial, sans-serif" font-size="36">Replace this with your own screenshot or art</text>
+</svg>

--- a/blogs/images/example-inline.svg
+++ b/blogs/images/example-inline.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Example inline image">
+  <rect width="1200" height="675" fill="#111827" />
+  <rect x="40" y="40" width="1120" height="595" fill="#1f2937" stroke="#fbbf24" stroke-width="4" />
+  <text x="100" y="280" fill="#fbbf24" font-family="Inter, Arial, sans-serif" font-size="58" font-weight="700">Inline Blog Image</text>
+  <text x="100" y="350" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="34">Keep images next to your post files for easy organization.</text>
+</svg>

--- a/blogs/index.json
+++ b/blogs/index.json
@@ -1,0 +1,7 @@
+{
+  "posts": [
+    {
+      "file": "blogs/example-launch-update.json"
+    }
+  ]
+}

--- a/config.json
+++ b/config.json
@@ -6,6 +6,14 @@
     "version": "1.0.0",
     "minecraftVersion": "1.20.1"
   },
+  "branding": {
+    "logo": {
+      "src": "images/site-logo.svg",
+      "alt": "Your Modpack Logo",
+      "width": 320,
+      "height": 72
+    }
+  },
   "links": {
     "curseforge": "https://www.curseforge.com/minecraft/modpacks/your-modpack",
     "discord": "",
@@ -15,22 +23,22 @@
     {
       "title": "Adventure-First Progression",
       "description": "Questing and milestone-based progression keep players moving forward without overwhelming them.",
-      "icon": "\ud83e\udded"
+      "icon": "🧭"
     },
     {
       "title": "High-Impact Combat",
       "description": "Face tougher encounters, unique bosses, and meaningful gear upgrades.",
-      "icon": "\u2694\ufe0f"
+      "icon": "⚔️"
     },
     {
       "title": "Worldbuilding Tools",
       "description": "Build ambitious bases with decorative and utility mods that work well together.",
-      "icon": "\ud83c\udff0"
+      "icon": "🏰"
     },
     {
       "title": "Multiplayer Friendly",
       "description": "Balanced settings and documentation make it easier to run a shared server.",
-      "icon": "\ud83e\udd1d"
+      "icon": "🤝"
     }
   ],
   "gallery": {
@@ -99,28 +107,8 @@
     "textColor": "#f8fafc"
   },
   "blog": {
-    "posts": [
-      {
-        "title": "v1.0 Release Notes",
-        "summary": "Highlights from launch week, progression changes, and top-reported fixes.",
-        "date": "2026-01-15",
-        "author": "Your Name",
-        "url": "https://example.com/blog/v1-0-release-notes"
-      },
-      {
-        "title": "Server Performance Guide",
-        "summary": "Suggested flags, pregeneration tips, and chunk loading rules for smoother worlds.",
-        "date": "2026-01-08",
-        "author": "Server Team",
-        "url": "https://example.com/blog/server-performance-guide"
-      },
-      {
-        "title": "Community Spotlight",
-        "summary": "Featured player builds, event recap, and what is coming next in the roadmap.",
-        "date": "2025-12-28",
-        "author": "Community Manager",
-        "url": "https://example.com/blog/community-spotlight"
-      }
-    ]
+    "source": "folder",
+    "indexFile": "blogs/index.json",
+    "posts": []
   }
 }

--- a/images/site-logo.svg
+++ b/images/site-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="72" viewBox="0 0 320 72" role="img" aria-label="Site logo">
+  <rect width="320" height="72" rx="12" fill="#111827" />
+  <text x="20" y="47" fill="#fbbf24" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="800">Wilderness Odyssey</text>
+</svg>

--- a/script.js
+++ b/script.js
@@ -37,7 +37,6 @@ const defaultGallery = [
     }
 ];
 
-
 const defaultBlogPosts = [
     {
         title: 'Version 1.0.0 Released',
@@ -80,7 +79,7 @@ async function loadConfig() {
         config = {};
     }
 
-    populateWebsite();
+    await populateWebsite();
     applyTheme();
 }
 
@@ -114,10 +113,11 @@ function getGithubUrls() {
     };
 }
 
-function populateWebsite() {
+async function populateWebsite() {
     document.title = config.modpack?.name || 'Modpack';
     document.getElementById('page-title').textContent = document.title;
-    document.getElementById('nav-logo').textContent = config.modpack?.name || 'Modpack';
+
+    applyBranding();
 
     document.getElementById('hero-title').textContent = config.modpack?.name || 'Your Modpack Name';
     document.getElementById('hero-tagline').textContent = config.modpack?.tagline || 'An Epic Adventure Awaits';
@@ -144,8 +144,36 @@ function populateWebsite() {
 
     populateFeatures();
     populateGallery();
-    populateBlogPosts();
+    await populateBlogPosts();
     populateWikiHub(githubUrls);
+}
+
+function applyBranding() {
+    const navLogo = document.getElementById('nav-logo');
+    const logoConfig = config.branding?.logo;
+    const logoImageUrl = logoConfig?.src || '';
+
+    if (!logoImageUrl) {
+        navLogo.textContent = config.modpack?.name || 'Modpack';
+        navLogo.classList.remove('nav-logo-image');
+        return;
+    }
+
+    navLogo.classList.add('nav-logo-image');
+    navLogo.innerHTML = '';
+
+    const logoImage = document.createElement('img');
+    logoImage.src = logoImageUrl;
+    logoImage.alt = logoConfig?.alt || `${config.modpack?.name || 'Modpack'} logo`;
+    logoImage.width = Number(logoConfig?.width) || 160;
+    logoImage.height = Number(logoConfig?.height) || 48;
+
+    logoImage.addEventListener('error', () => {
+        navLogo.classList.remove('nav-logo-image');
+        navLogo.textContent = config.modpack?.name || 'Modpack';
+    }, { once: true });
+
+    navLogo.appendChild(logoImage);
 }
 
 function populateFeatures() {
@@ -191,7 +219,6 @@ function populateGallery() {
     });
 }
 
-
 function formatBlogDate(value) {
     if (!value) {
         return 'Recent update';
@@ -209,13 +236,109 @@ function formatBlogDate(value) {
     });
 }
 
-function populateBlogPosts() {
+async function loadBlogPostsFromFolder() {
+    const blogIndexPath = config.blog?.indexFile || 'blogs/index.json';
+
+    try {
+        const indexResponse = await fetch(blogIndexPath);
+        if (!indexResponse.ok) {
+            throw new Error(`Unable to load ${blogIndexPath}`);
+        }
+
+        const blogIndex = await indexResponse.json();
+        const entries = blogIndex.posts || [];
+
+        const loadedPosts = await Promise.all(entries.map(async (entry) => {
+            const postFile = typeof entry === 'string' ? entry : entry.file;
+            if (!postFile) {
+                return null;
+            }
+
+            const postResponse = await fetch(postFile);
+            if (!postResponse.ok) {
+                throw new Error(`Unable to load ${postFile}`);
+            }
+
+            const post = await postResponse.json();
+            return {
+                ...post,
+                url: post.url || (typeof entry === 'object' ? entry.url : ''),
+                sourceFile: postFile
+            };
+        }));
+
+        return loadedPosts.filter(Boolean);
+    } catch (error) {
+        console.error('Failed to load blog posts from folder:', error);
+        return [];
+    }
+}
+
+function renderBlogContent(container, contentBlocks = []) {
+    if (!contentBlocks.length) {
+        return;
+    }
+
+    contentBlocks.forEach((block) => {
+        if (block.type === 'heading') {
+            const heading = document.createElement('h4');
+            heading.textContent = block.text || 'Section';
+            container.appendChild(heading);
+            return;
+        }
+
+        if (block.type === 'image') {
+            const figure = document.createElement('figure');
+            figure.className = 'blog-figure';
+
+            const image = document.createElement('img');
+            image.src = block.src || '';
+            image.alt = block.alt || 'Blog image';
+            image.loading = 'lazy';
+            figure.appendChild(image);
+
+            if (block.caption) {
+                const caption = document.createElement('figcaption');
+                caption.textContent = block.caption;
+                figure.appendChild(caption);
+            }
+
+            container.appendChild(figure);
+            return;
+        }
+
+        if (block.type === 'list' && Array.isArray(block.items)) {
+            const list = document.createElement('ul');
+            block.items.forEach((itemText) => {
+                const listItem = document.createElement('li');
+                listItem.textContent = itemText;
+                list.appendChild(listItem);
+            });
+            container.appendChild(list);
+            return;
+        }
+
+        const paragraph = document.createElement('p');
+        paragraph.textContent = block.text || '';
+        container.appendChild(paragraph);
+    });
+}
+
+async function populateBlogPosts() {
     const blogGrid = document.getElementById('blog-grid');
     if (!blogGrid) {
         return;
     }
 
-    const posts = config.blog?.posts?.length ? config.blog.posts : defaultBlogPosts;
+    let posts = [];
+    if (config.blog?.source === 'folder' || config.blog?.indexFile) {
+        posts = await loadBlogPostsFromFolder();
+    }
+
+    if (!posts.length) {
+        posts = config.blog?.posts?.length ? config.blog.posts : defaultBlogPosts;
+    }
+
     blogGrid.innerHTML = '';
 
     posts.forEach((post) => {
@@ -226,15 +349,48 @@ function populateBlogPosts() {
         const postSummary = post.summary || 'Share an update with your community.';
         const postAuthor = post.author || 'Modpack Team';
         const postUrl = post.url || '#';
+        const coverImage = post.coverImage || '';
 
         article.innerHTML = `
             <p class="blog-meta">${formatBlogDate(post.date)} · ${postAuthor}</p>
             <h3>${postTitle}</h3>
             <p>${postSummary}</p>
-            <a class="blog-link" href="${postUrl}" ${postUrl === '#' ? '' : 'target="_blank" rel="noopener noreferrer"'}>
-                Read update →
-            </a>
         `;
+
+        if (coverImage) {
+            const image = document.createElement('img');
+            image.className = 'blog-cover-image';
+            image.src = coverImage;
+            image.alt = `${postTitle} cover image`;
+            image.loading = 'lazy';
+            article.appendChild(image);
+        }
+
+        if (Array.isArray(post.content) && post.content.length) {
+            const details = document.createElement('details');
+            details.className = 'blog-details';
+
+            const summary = document.createElement('summary');
+            summary.textContent = 'Read full post';
+            details.appendChild(summary);
+
+            const content = document.createElement('div');
+            content.className = 'blog-content';
+            renderBlogContent(content, post.content);
+            details.appendChild(content);
+
+            article.appendChild(details);
+        } else {
+            const link = document.createElement('a');
+            link.className = 'blog-link';
+            link.href = postUrl;
+            link.textContent = 'Read update →';
+            if (postUrl !== '#') {
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+            }
+            article.appendChild(link);
+        }
 
         blogGrid.appendChild(article);
     });

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,18 @@ a {
     letter-spacing: 0.02em;
 }
 
+.nav-logo.nav-logo-image {
+    display: inline-flex;
+    align-items: center;
+}
+
+.nav-logo.nav-logo-image img {
+    display: block;
+    width: auto;
+    max-height: 48px;
+    object-fit: contain;
+}
+
 .nav-menu {
     list-style: none;
     display: flex;
@@ -277,6 +289,54 @@ a {
 
 .blog-link:hover {
     color: var(--accent-color);
+}
+
+.blog-cover-image {
+    width: 100%;
+    border-radius: 0.75rem;
+    border: 1px solid var(--border-color);
+}
+
+.blog-details {
+    margin-top: 0.2rem;
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.55rem;
+}
+
+.blog-details summary {
+    cursor: pointer;
+    font-weight: 700;
+    color: var(--accent-color);
+}
+
+.blog-content {
+    margin-top: 0.65rem;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.blog-content h4 {
+    color: var(--text-color);
+}
+
+.blog-content ul {
+    padding-left: 1.2rem;
+}
+
+.blog-figure {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.blog-figure img {
+    width: 100%;
+    border-radius: 0.75rem;
+    border: 1px solid var(--border-color);
+}
+
+.blog-figure figcaption {
+    color: var(--muted-text);
+    font-size: 0.85rem;
 }
 
 .gallery-item {


### PR DESCRIPTION
### Motivation
- Provide an easy way to brand the site with either text or an image logo configurable from `config.json`.
- Make blog content manageable in-repo by supporting a file-based `blogs/` folder where posts can include inline images and structured content.
- Ship an example blog and assets so maintainers have a working template to copy and extend.

### Description
- Add optional `branding.logo` to `config.json` and render it in the navbar via a new `applyBranding()` helper in `script.js`, falling back to text when the image fails or is not configured.
- Implement folder-based blog loading with `blogs/index.json` and `loadBlogPostsFromFolder()` and add `renderBlogContent()` to support paragraphs, headings, lists, and inline images with captions.
- Support per-post `coverImage` and collapsible full post content (`<details>`), and update `populateBlogPosts()` to prefer folder-sourced posts when `blog.source` is `folder`.
- Update styling in `styles.css` for `.nav-logo.nav-logo-image`, blog cover/content/figure styles, add example files (`blogs/example-launch-update.json`, `blogs/images/*`, `images/site-logo.svg`) and refresh `README.md` to document the new workflows.

### Testing
- Ran JSON validation for modified/added manifests with `python3 -m json.tool config.json`, `python3 -m json.tool blogs/index.json`, and `python3 -m json.tool blogs/example-launch-update.json`, which all succeeded.
- Served the site locally with `python3 -m http.server 4173` and exercised the UI via an automated Playwright screenshot against `http://127.0.0.1:4173`, which completed and produced a capture showing the logo and example blog.
- The blog index and example post were fetched successfully during the local preview (no errors in automated fetch steps reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699606f4bf7c8328bbe521fd2f42cde7)