### PR TITLE
Revamp README into a unique CurseForge-style modpack page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,160 @@
-# Wilderness-Odyssey.
-this project is in its alpha phase almost beta
-its a exploration/adventure modpack.
+<div align="center">
+
+# 🧭 Wilderness Odyssey
+### *A CurseForge-style NeoForge Modpack Page*
+
+![Minecraft](https://img.shields.io/badge/Minecraft-1.21.1-3C8527?style=for-the-badge&logo=minecraft&logoColor=white)
+![Loader](https://img.shields.io/badge/Loader-NeoForge%2021.1.176-2E7D32?style=for-the-badge)
+![Status](https://img.shields.io/badge/Status-Alpha%20%E2%86%92%20Beta-orange?style=for-the-badge)
+![Focus](https://img.shields.io/badge/Theme-Exploration%20%7C%20Adventure-7B5CFF?style=for-the-badge)
+
+</div>
+
+---
+
+## 🌲 Welcome, Traveler
+**Wilderness Odyssey** is a handcrafted adventure/exploration modpack built for players who want danger, discovery, atmosphere, and unforgettable world generation.
+
+> You are not loading a world.
+> You are launching an expedition.
+
+---
+
+## ✨ What Makes This Pack Different
+
+- **Exploration-First Design** – vast biome variety, deeper cave journeys, and high-value structure hunting.
+- **Alive World Feel** – weather, ambient visuals, improved entity presence, and immersive environmental mood.
+- **Performance-Conscious** – includes modern optimization mods for smoother traversal and combat.
+- **Curated Balance** – tuned to stay adventurous without becoming pure grind.
+
+---
+
+## 🗺️ Expedition Snapshot
+
+| Category | Details |
+|---|---|
+| **Minecraft Version** | `1.21.1` |
+| **Mod Loader** | `NeoForge 21.1.176` |
+| **Pack Stage** | `Alpha (approaching Beta)` |
+| **Core Vibe** | `Adventure • Exploration • Survival Atmosphere` |
+| **Known Pillars** | Worldgen, structures, mobs, immersion, optimization |
+
+---
+
+## 🧩 Featured Mod Highlights
+
+<details>
+<summary><strong>🌍 World Generation & Biomes</strong></summary>
+
+- **Terralith**
+- **Regions Unexplored**
+- **Oh The Biomes We've Gone**
+- **Geophilic**
+- **Repurposed Structures**
+- **Towns and Towers**
+- **Sky Villages**
+
+</details>
+
+<details>
+<summary><strong>⚔️ Adventure, Creatures & Survival Flavor</strong></summary>
+
+- **Nyf's Spiders**
+- **Ribbits**
+- **Living Things**
+- **Aquaculture 2**
+- **Waddles**
+- **Variants & Ventures**
+
+</details>
+
+<details>
+<summary><strong>🚀 Performance & Client Experience</strong></summary>
+
+- **Sodium + Sodium Extra**
+- **Lithium**
+- **ModernFix**
+- **FerriteCore**
+- **Noisium**
+- **ImmediatelyFast**
+- **EntityCulling**
+
+</details>
+
+---
+
+## 🎮 Playstyle Selector *(Unique Feature)*
+Pick your expedition style and self-impose rules for extra fun:
+
+- [ ] **Pathfinder Mode** – No minimap-style assistance, rely on landmarks and memory.
+- [ ] **Relic Hunter Mode** – Prioritize structures, collect one trophy per major biome.
+- [ ] **Nomad Mode** – No permanent base before first rare structure clear.
+- [ ] **Stormwalker Mode** – Travel during bad weather for risk/reward atmosphere runs.
+
+---
+
+## 📦 CurseForge Page Layout Template *(Unique Feature)*
+Use this section directly when publishing on CurseForge:
+
+```text
+Wilderness Odyssey is a NeoForge 1.21.1 adventure/exploration modpack focused on biome diversity,
+meaningful structure discovery, immersive world atmosphere, and optimized performance.
+
+Recommended for players who enjoy long-form survival journeys, scenic base locations,
+and dangerous exploration loops over automation-heavy progression.
+```
+
+### Suggested CurseForge Sections
+- **Overview** → Use “Welcome, Traveler” + “What Makes This Pack Different”
+- **Features** → Use “Featured Mod Highlights” dropdown groups
+- **Getting Started** → Add your installation + first-day tips
+- **Known Issues** → Keep short, update each release
+- **Changelog** → Mirror the `Changelogs/` folder entries
+
+---
+
+## 🧭 First 30 Minutes Route *(Unique Feature)*
+1. Secure early food + bed.
+2. Scout for your first landmark structure.
+3. Mark at least **3 distinct biome resources**.
+4. Craft exploration supplies before deep cave pushes.
+5. Return with loot, then plan the next expedition radius.
+
+---
+
+## ⚙️ Installation
+1. Install the **CurseForge App** (or Prism Launcher with NeoForge support).
+2. Import/download **Wilderness Odyssey**.
+3. Allocate RAM based on your system (commonly 6–8 GB for large packs).
+4. Launch and let first-time resource generation complete.
+
+---
+
+## 🔧 Compatibility Notes
+- Built around **NeoForge**.
+- Best experience with included configs, shaders, and resource packs.
+- If adding extra mods, test in a backup profile first.
+
+---
+
+## 📢 Development Status
+`Alpha → Beta transition in progress.`
+
+Expect:
+- Ongoing balancing
+- Worldgen tuning
+- Stability and polish updates
+
+---
+
+## ❤️ Credits
+Huge thanks to every mod author whose work powers this adventure.
+Please support creators on their official project pages.
+
+---
+
+## 🏕️ Final Word
+If you want a pack that rewards curiosity, route-planning, and brave exploration,
+**Wilderness Odyssey** is your next journey.
+
+> Pack your gear. Follow the horizon. Write your legend.


### PR DESCRIPTION
### Motivation
- Replace the minimal placeholder `README.md` with a publish-ready, richly formatted landing page suitable for a CurseForge modpack listing. 
- Improve user onboarding and presentation so the pack reads like a curated NeoForge modpack (version, loader, highlights, and install notes). 
- Add distinct, pack-specific features to make the CurseForge page stand out and help new players (playstyle checklist, first 30 minutes route, and copy/paste template). 

### Description
- Rewrote the entire `README.md` with a centered hero section, badges, and a stronger pack pitch tuned for `Minecraft 1.21.1` and `NeoForge 21.1.176`. 
- Added grouped, collapsible mod highlight sections using `<details>` blocks and a clear `Expedition Snapshot` table with version and pack-stage metadata. 
- Introduced three unique features: a `Playstyle Selector` checklist, a `First 30 Minutes Route` onboarding flow, and a `CurseForge Page Layout Template` block for copy/paste. 
- Cleaned trailing whitespace, staged the file, and committed the documentation change in `README.md`. 

### Testing
- Ran `git diff --check` to validate whitespace and markdown issues, which succeeded. 
- Verified the working tree status with `git status --short` and committed the change using `git commit`, both operations completed successfully. 
- Previewed the updated file with `nl -ba README.md` to confirm content layout and formatting, which produced the expected output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a775d3374c8328864af250e952c667)